### PR TITLE
Code quality fix - Math operands should be cast before assignment.

### DIFF
--- a/src/main/java/uk/org/okapibarcode/backend/Code2Of5.java
+++ b/src/main/java/uk/org/okapibarcode/backend/Code2Of5.java
@@ -508,7 +508,7 @@ public class Code2Of5 extends Symbol {
             } else {
                 baseline = getHeight() + fontSize;
             }
-            double centerX = getWidth() / 2;
+            double centerX = getWidth() / 2.0;
             texts.add(new TextBox(centerX, baseline, readable));
         }
     }

--- a/src/main/java/uk/org/okapibarcode/backend/Symbol.java
+++ b/src/main/java/uk/org/okapibarcode/backend/Symbol.java
@@ -627,7 +627,7 @@ public abstract class Symbol {
             } else {
                 baseline = getHeight() + fontSize;
             }
-            double centerX = getWidth() / 2;
+            double centerX = getWidth() / 2.0;
             texts.add(new TextBox(centerX, baseline, readable));
         }
     }

--- a/src/main/java/uk/org/okapibarcode/backend/UspsPackage.java
+++ b/src/main/java/uk/org/okapibarcode/backend/UspsPackage.java
@@ -130,7 +130,7 @@ public class UspsPackage extends Symbol{
         rectangles.add(topBar);
         rectangles.add(bottomBar);
 
-        double centerX = getWidth() / 2;
+        double centerX = getWidth() / 2.0;
         texts.add(new TextBox(centerX, getHeight() - 6.0, readable));
         texts.add(new TextBox(centerX, 12.0, banner));
     }

--- a/src/main/java/uk/org/okapibarcode/gui/OkapiUI.java
+++ b/src/main/java/uk/org/okapibarcode/gui/OkapiUI.java
@@ -2210,9 +2210,9 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
             return;
         }
 
-        bWidth = topPanel.getWidth() / (symbol.getWidth() + (2 * symbol.getBorderWidth()) + (2 * symbol.getWhitespaceWidth()));
+        bWidth = (double) topPanel.getWidth() / (symbol.getWidth() + (2 * symbol.getBorderWidth()) + (2 * symbol.getWhitespaceWidth()));
 
-        bHeight = topPanel.getHeight() / (symbol.getHeight() + (2 * symbol.getBorderWidth()) + symbol.getHumanReadableHeight());
+        bHeight = (double) topPanel.getHeight() / (symbol.getHeight() + (2 * symbol.getBorderWidth()) + symbol.getHumanReadableHeight());
 
         if (bWidth < bHeight) {
             factor = (int) bWidth;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2184 - Math operands should be cast before assignment.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2184
Please let me know if you have any questions.

Faisal Hameed