### PR TITLE
Code quality fix - Literal boolean values should not be used in condition expressions.

### DIFF
--- a/src/main/java/uk/org/okapibarcode/OkapiBarcode.java
+++ b/src/main/java/uk/org/okapibarcode/OkapiBarcode.java
@@ -42,7 +42,7 @@ public class OkapiBarcode {
         Settings settings = new Settings();
         new JCommander(settings, args);
 
-        if (settings.isGuiSupressed() == false) {
+        if (!settings.isGuiSupressed()) {
             OkapiUI okapiUi = new OkapiUI();
             okapiUi.setVisible(true);
         } else {

--- a/src/main/java/uk/org/okapibarcode/backend/AztecCode.java
+++ b/src/main/java/uk/org/okapibarcode/backend/AztecCode.java
@@ -594,7 +594,7 @@ public class AztecCode extends Symbol {
             return false;
         }
 
-        if (generateAztecBinary() == false) {
+        if (!generateAztecBinary()) {
             error_msg = "Input too long or too many extended ASCII characters";
             return false;
         }

--- a/src/main/java/uk/org/okapibarcode/backend/CodablockF.java
+++ b/src/main/java/uk/org/okapibarcode/backend/CodablockF.java
@@ -823,7 +823,7 @@ public class CodablockF extends Symbol {
             black = true;
             x = 0;
             for (xBlock = 0; xBlock < pattern[yBlock].length(); xBlock++) {
-                if (black == true) {
+                if (black) {
                     black = false;
                     w = pattern[yBlock].charAt(xBlock) - '0';
                     if (row_height[yBlock] == -1) {

--- a/src/main/java/uk/org/okapibarcode/backend/Code16k.java
+++ b/src/main/java/uk/org/okapibarcode/backend/Code16k.java
@@ -433,7 +433,7 @@ public class Code16k extends Symbol {
                 }
             }
             if (read != 0) {
-                if ((fset[read] == 'F') && (f_state == false)) {
+                if ((fset[read] == 'F') && !f_state) {
                     /* Latch beginning of extended mode */
                     switch (current_set) {
                     case 'A':
@@ -448,7 +448,7 @@ public class Code16k extends Symbol {
                     bar_characters += 2;
                     f_state = true;
                 }
-                if ((fset[read] == ' ') && (f_state == true)) {
+                if ((fset[read] == ' ') && f_state) {
                     /* Latch end of extended mode */
                     switch (current_set) {
                     case 'A':
@@ -759,7 +759,7 @@ public class Code16k extends Symbol {
             black = true;
             x = 15;
             for (xBlock = 0; xBlock < pattern[yBlock].length(); xBlock++) {
-                if (black == true) {
+                if (black) {
                     black = false;
                     w = pattern[yBlock].charAt(xBlock) - '0';
                     if (row_height[yBlock] == -1) {

--- a/src/main/java/uk/org/okapibarcode/backend/Code49.java
+++ b/src/main/java/uk/org/okapibarcode/backend/Code49.java
@@ -1326,7 +1326,7 @@ public class Code49 extends Symbol {
             black = true;
             x = 15;
             for (xBlock = 0; xBlock < pattern[yBlock].length(); xBlock++) {
-                if (black == true) {
+                if (black) {
                     black = false;
                     w = pattern[yBlock].charAt(xBlock) - '0';
                     if (row_height[yBlock] == -1) {

--- a/src/main/java/uk/org/okapibarcode/backend/Composite.java
+++ b/src/main/java/uk/org/okapibarcode/backend/Composite.java
@@ -1886,7 +1886,7 @@ public class Composite extends Symbol {
             } while ((i + latchOffset) < general_field.length());
         }
 
-        if (calculateSymbolSize() == false) {
+        if (!calculateSymbolSize()) {
             return false;
         }
 
@@ -1932,7 +1932,7 @@ public class Composite extends Symbol {
         }
 
         /* size of the symbol may have changed when adding data in the above sequence */
-        if (calculateSymbolSize() == false) {
+        if (!calculateSymbolSize()) {
             return false;
         }
 

--- a/src/main/java/uk/org/okapibarcode/backend/DataBarExpanded.java
+++ b/src/main/java/uk/org/okapibarcode/backend/DataBarExpanded.java
@@ -190,7 +190,7 @@ public class DataBarExpanded extends Symbol {
             binary_string = "0";
             compositeOffset = 0;
         }
-        if (calculateBinaryString() == false) {
+        if (!calculateBinaryString()) {
             return false;
         }
 

--- a/src/main/java/uk/org/okapibarcode/backend/Ean.java
+++ b/src/main/java/uk/org/okapibarcode/backend/Ean.java
@@ -287,7 +287,7 @@ public class Ean extends Symbol {
             compositeOffset = 6;
         }
         for (xBlock = 0; xBlock < pattern[0].length(); xBlock++) {
-            if (black == true) {
+            if (black) {
                 y = 0;
                 black = false;
                 w = pattern[0].charAt(xBlock) - '0';

--- a/src/main/java/uk/org/okapibarcode/backend/Postnet.java
+++ b/src/main/java/uk/org/okapibarcode/backend/Postnet.java
@@ -66,7 +66,7 @@ public class Postnet extends Symbol {
             retval = makePlanet();
         }
 
-        if (retval == true) {
+        if (retval) {
             plotSymbol();
         }
 

--- a/src/main/java/uk/org/okapibarcode/backend/Upc.java
+++ b/src/main/java/uk/org/okapibarcode/backend/Upc.java
@@ -129,7 +129,7 @@ public class Upc extends Symbol {
             }
         }
 
-        if (retval == true) {
+        if (retval) {
             plotSymbol();
         }
         return retval;
@@ -364,7 +364,7 @@ public class Upc extends Symbol {
             compositeOffset = 6;
         }
         for (xBlock = 0; xBlock < pattern[0].length(); xBlock++) {
-            if (black == true) {
+            if (black) {
                 y = 0;
                 black = false;
                 w = pattern[0].charAt(xBlock) - '0';


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1125 - Literal boolean values should not be used in condition expressions. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1125

Please let me know if you have any questions.

Faisal Hameed