### PR TITLE
Code quality fix - Array designators "[]" should be on the type, not the variable.

### DIFF
--- a/src/main/java/uk/org/okapibarcode/backend/Code128.java
+++ b/src/main/java/uk/org/okapibarcode/backend/Code128.java
@@ -107,7 +107,7 @@ public class Code128 extends Symbol {
         double glyph_count;
         int bar_characters = 0, total_sum = 0;
         FMode f_state = FMode.LATCHN;
-        int values[] = new int[200];
+        int[] values = new int[200];
         int c;
         String dest = "";
         int[] inputData;
@@ -131,8 +131,8 @@ public class Code128 extends Symbol {
             inputData[i] = inputBytes[i] & 0xFF;
         }
 
-        FMode fset[] = new FMode[200];
-        Mode set[] = new Mode[200]; /* set[] = Calculated mode for each character */
+        FMode[] fset = new FMode[200];
+        Mode[] set = new Mode[200]; /* set[] = Calculated mode for each character */
 
         if (sourcelen > 170) {
             error_msg = "Input data too long";

--- a/src/main/java/uk/org/okapibarcode/backend/Code16k.java
+++ b/src/main/java/uk/org/okapibarcode/backend/Code16k.java
@@ -592,7 +592,7 @@ public class Code16k extends Symbol {
         }
     }
 
-    private void getValueSubsetC(int source_a, int source_b, int values[], int bar_chars) {
+    private void getValueSubsetC(int source_a, int source_b, int[] values, int bar_chars) {
         int weight;
 
         weight = (10 * Character.getNumericValue(source_a)) + Character.getNumericValue(source_b);

--- a/src/main/java/uk/org/okapibarcode/backend/Code3Of9.java
+++ b/src/main/java/uk/org/okapibarcode/backend/Code3Of9.java
@@ -32,7 +32,7 @@ public class Code3Of9 extends Symbol {
         NONE, MOD43
     }
 
-    private static final String CODE_39[] = {
+    private static final String[] CODE_39 = {
         "1112212111", "2112111121", "1122111121", "2122111111", "1112211121",
         "2112211111", "1122211111", "1112112121", "2112112111", "1122112111",
         "2111121121", "1121121121", "2121121111", "1111221121", "2111221111",
@@ -44,7 +44,7 @@ public class Code3Of9 extends Symbol {
         "1212111211", "1211121211", "1112121211"
     };
 
-    private static final char LOOKUP[] = {
+    private static final char[] LOOKUP = {
         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D',
         'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R',
         'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '-', '.', ' ', '$', '/', '+',

--- a/src/main/java/uk/org/okapibarcode/backend/Code3Of9Extended.java
+++ b/src/main/java/uk/org/okapibarcode/backend/Code3Of9Extended.java
@@ -25,7 +25,7 @@ package uk.org.okapibarcode.backend;
  */
 public class Code3Of9Extended extends Symbol {
 
-    private final String ECode39[] = {
+    private final String[] ECode39 = {
         "%U", "$A", "$B", "$C", "$D", "$E", "$F", "$G", "$H", "$I", "$J", "$K",
         "$L", "$M", "$N", "$O", "$P", "$Q", "$R", "$S", "$T", "$U", "$V", "$W",
         "$X", "$Y", "$Z", "%A", "%B", "%C", "%D", "%E", " ", "/A", "/B", "/C",

--- a/src/main/java/uk/org/okapibarcode/backend/Code49.java
+++ b/src/main/java/uk/org/okapibarcode/backend/Code49.java
@@ -28,7 +28,7 @@ import java.awt.geom.Rectangle2D;
  */
 public class Code49 extends Symbol {
 
-    private String c49_table7[] = {
+    private String[] c49_table7 = {
         /* Table 7: Code 49 ASCII Chart */
         "! ", "!A", "!B", "!C", "!D", "!E", "!F", "!G", "!H", "!I", "!J", "!K",
         "!L", "!M", "!N", "!O", "!P", "!Q", "!R", "!S", "!T", "!U", "!V", "!W",
@@ -44,27 +44,27 @@ public class Code49 extends Symbol {
     };
 
     /* Table 5: Check Character Weighting Values */
-    private int c49_x_weight[] = {
+    private int[] c49_x_weight = {
         1, 9, 31, 26, 2, 12, 17, 23, 37, 18, 22, 6, 27, 44, 15, 43, 39, 11, 13,
         5, 41, 33, 36, 8, 4, 32, 3, 19, 40, 25, 29, 10
     };
 
-    private int c49_y_weight[] = {
+    private int[] c49_y_weight = {
         9, 31, 26, 2, 12, 17, 23, 37, 18, 22, 6, 27, 44, 15, 43, 39, 11, 13, 5,
         41, 33, 36, 8, 4, 32, 3, 19, 40, 25, 29, 10, 24
     };
 
-    private int c49_z_weight[] = {
+    private int[] c49_z_weight = {
         31, 26, 2, 12, 17, 23, 37, 18, 22, 6, 27, 44, 15, 43, 39, 11, 13, 5, 41,
         33, 36, 8, 4, 32, 3, 19, 40, 25, 29, 10, 24, 30
     };
 
-    private String c49_table4[] = {
+    private String[] c49_table4 = {
         /* Table 4: Row Parity Pattern for Code 49 Symbols */
         "OEEO", "EOEO", "OOEE", "EEOO", "OEOE", "EOOE", "OOOO", "EEEE"
     };
 
-    private String c49_appxe_even[] = {
+    private String[] c49_appxe_even = {
         /* Appendix E - Code 49 Encodation Patterns (Even Symbol Character Parity) */
         /* Column 1 */
         "11521132", "25112131", "14212132", "25121221", "14221222", "12412132",
@@ -524,7 +524,7 @@ public class Code49 extends Symbol {
         "15121132", "24221131", "13321132", "22421131"
     };
 
-    private String c49_appxe_odd[] = {
+    private String[] c49_appxe_odd = {
         /* Appendix E - Code 49 Encodation Patterns (Odd Symbol Character Parity) */
         /* Column 1 */
         "22121116", "42121114", "31221115", "51221113", "32112115", "52112113",
@@ -984,7 +984,7 @@ public class Code49 extends Symbol {
         "11131162", "21122161", "21131251", "11113162"
     };
 
-    private char C49_Set[] = {
+    private char[] C49_Set = {
         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D',
         'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R',
         'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '-', '.', ' ', '$', '/', '+',
@@ -998,9 +998,9 @@ public class Code49 extends Symbol {
         int x_count, y_count, z_count, posn_val, local_value;
         String intermediate = "";
         String localpattern = "";
-        int codewords[] = new int[170];
-        int c_grid[][] = new int[8][8];
-        int w_grid[][] = new int[8][4];
+        int[] codewords = new int[170];
+        int[][] c_grid = new int[8][8];
+        int[][] w_grid = new int[8][4];
 
         if (!content.matches("[\u0000-\u007F]+")) {
             error_msg = "Invalid characters in input data";

--- a/src/main/java/uk/org/okapibarcode/backend/MicroQrCode.java
+++ b/src/main/java/uk/org/okapibarcode/backend/MicroQrCode.java
@@ -138,7 +138,7 @@ public class MicroQrCode extends Symbol {
         0x2a51, 0x34e3, 0x31d4, 0x3e8d, 0x3bba
     };
 
-    private static final int MICRO_QR_SIZES[] = {
+    private static final int[] MICRO_QR_SIZES = {
         11, 13, 15, 17
     };
 
@@ -1404,7 +1404,7 @@ public class MicroQrCode extends Symbol {
     private void placeFinderPattern(int size, int x, int y) {
         int xp, yp;
 
-        int finder[] = {
+        int[] finder = {
             1, 1, 1, 1, 1, 1, 1,
             1, 0, 0, 0, 0, 0, 1,
             1, 0, 1, 1, 1, 0, 1,

--- a/src/main/java/uk/org/okapibarcode/backend/MsiPlessey.java
+++ b/src/main/java/uk/org/okapibarcode/backend/MsiPlessey.java
@@ -45,7 +45,7 @@ public class MsiPlessey extends Symbol {
         checkOption = checkMode;
     }
 
-    private final String MSI_PlessTable[] = {
+    private final String[] MSI_PlessTable = {
         "12121212", "12121221", "12122112", "12122121", "12211212", "12211221",
         "12212112", "12212121", "21121212", "21121221"
     };

--- a/src/main/java/uk/org/okapibarcode/backend/Pdf417.java
+++ b/src/main/java/uk/org/okapibarcode/backend/Pdf417.java
@@ -46,8 +46,8 @@ public class Pdf417 extends Symbol {
         FALSE, TEX, BYT, NUM
     };
 
-    private int blockLength[] = new int[1000];
-    private EncodingMode blockType[] = new EncodingMode[1000];
+    private int[] blockLength = new int[1000];
+    private EncodingMode[] blockType = new EncodingMode[1000];
     private int blockIndex;
     private int[] codeWords = new int[2700];
     private int codeWordCount;

--- a/src/main/java/uk/org/okapibarcode/backend/QrCode.java
+++ b/src/main/java/uk/org/okapibarcode/backend/QrCode.java
@@ -1546,7 +1546,7 @@ public class QrCode extends Symbol {
     private void place_finder(int size, int x, int y) {
         int xp, yp;
 
-        int finder[] = {
+        int[] finder = {
             1, 1, 1, 1, 1, 1, 1,
             1, 0, 0, 0, 0, 0, 1,
             1, 0, 1, 1, 1, 0, 1,
@@ -1570,7 +1570,7 @@ public class QrCode extends Symbol {
     private void place_align(int size, int x, int y) {
         int xp, yp;
 
-        int alignment[] = {
+        int[] alignment = {
             1, 1, 1, 1, 1,
             1, 0, 0, 0, 1,
             1, 0, 1, 0, 1,

--- a/src/main/java/uk/org/okapibarcode/gui/AboutOkapi.java
+++ b/src/main/java/uk/org/okapibarcode/gui/AboutOkapi.java
@@ -97,7 +97,7 @@ public class AboutOkapi extends javax.swing.JFrame {
     /**
      * @param args the command line arguments
      */
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         /* Set the Nimbus look and feel */
         //<editor-fold defaultstate="collapsed" desc=" Look and feel setting code (optional) ">
         /* If Nimbus (introduced in Java SE 6) is not available, stay with the default look and feel.

--- a/src/main/java/uk/org/okapibarcode/gui/AddComposite.java
+++ b/src/main/java/uk/org/okapibarcode/gui/AddComposite.java
@@ -122,7 +122,7 @@ public class AddComposite extends javax.swing.JFrame {
     /**
      * @param args the command line arguments
      */
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         /* Set the Nimbus look and feel */
         //<editor-fold defaultstate="collapsed" desc=" Look and feel setting code (optional) ">
         /* If Nimbus (introduced in Java SE 6) is not available, stay with the default look and feel.

--- a/src/main/java/uk/org/okapibarcode/gui/MoreData.java
+++ b/src/main/java/uk/org/okapibarcode/gui/MoreData.java
@@ -167,7 +167,7 @@ public class MoreData extends javax.swing.JFrame {
     /**
      * @param args the command line arguments
      */
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         /* Set the Nimbus look and feel */
         //<editor-fold defaultstate="collapsed" desc=" Look and feel setting code (optional) ">
         /* If Nimbus (introduced in Java SE 6) is not available, stay with the default look and feel.

--- a/src/main/java/uk/org/okapibarcode/gui/OkapiUI.java
+++ b/src/main/java/uk/org/okapibarcode/gui/OkapiUI.java
@@ -2084,7 +2084,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
     /**
      * @param args the command line arguments
      */
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         /* Set the Nimbus look and feel */
         //<editor-fold defaultstate="collapsed" desc=" Look and feel setting code (optional) ">
         /* If Nimbus (introduced in Java SE 6) is not available, stay with the default look and feel.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1197 - Array designators "[]" should be on the type, not the variable.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1197

Please let me know if you have any questions.

Faisal Hameed