### PR TITLE
Code quality fix - "@Override" annotation should be used on any method overriding.

### DIFF
--- a/src/main/java/uk/org/okapibarcode/gui/OkapiUI.java
+++ b/src/main/java/uk/org/okapibarcode/gui/OkapiUI.java
@@ -320,6 +320,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
 
         loadDataButton.setText("...");
         loadDataButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 loadDataButtonActionPerformed(evt);
             }
@@ -352,6 +353,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
         addCompositeButton.setText("...");
         addCompositeButton.setEnabled(false);
         addCompositeButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 addCompositeButtonActionPerformed(evt);
             }
@@ -359,6 +361,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
 
         useGS1Check.setText("Use GS1 Data Encodation");
         useGS1Check.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 useGS1CheckActionPerformed(evt);
             }
@@ -366,6 +369,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
 
         useCompositeCheck.setText("Add Composite Component");
         useCompositeCheck.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 useCompositeCheckActionPerformed(evt);
             }
@@ -438,6 +442,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
 
         batchFileButton.setText("Import");
         batchFileButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 batchFileButtonActionPerformed(evt);
             }
@@ -445,6 +450,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
 
         createButton.setText("Create");
         createButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 createButtonActionPerformed(evt);
             }
@@ -467,6 +473,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
         runBatchButton.setText("Run Batch");
         runBatchButton.setEnabled(false);
         runBatchButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 runBatchButtonActionPerformed(evt);
             }
@@ -476,6 +483,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
 
         directoryButton.setText("Select Directory");
         directoryButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 directoryButtonActionPerformed(evt);
             }
@@ -483,6 +491,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
 
         resetButton.setText("Reset");
         resetButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 resetButtonActionPerformed(evt);
             }
@@ -591,6 +600,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
 
         inkButton.setText("Select Ink Colour");
         inkButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 inkButtonActionPerformed(evt);
             }
@@ -598,6 +608,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
 
         paperButton.setText("Select Paper Colour");
         paperButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 paperButtonActionPerformed(evt);
             }
@@ -605,6 +616,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
 
         resetColourButton.setText("Reset Colours");
         resetColourButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 resetColourButtonActionPerformed(evt);
             }
@@ -618,6 +630,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
         aztecAutoSize.setSelected(true);
         aztecAutoSize.setText("Automatic Resizing");
         aztecAutoSize.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 aztecAutoSizeActionPerformed(evt);
             }
@@ -626,6 +639,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
         aztecButtonGroup.add(aztecUserSize);
         aztecUserSize.setText("Adjust Size To:");
         aztecUserSize.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 aztecUserSizeActionPerformed(evt);
             }
@@ -634,6 +648,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
         aztecButtonGroup.add(aztecUserEcc);
         aztecUserEcc.setText("Add Minimum Error Correction:");
         aztecUserEcc.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 aztecUserEccActionPerformed(evt);
             }
@@ -642,6 +657,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
         aztecUserSizeCombo.setModel(new javax.swing.DefaultComboBoxModel(new String[] { "15 X 15 Compact", "19 X 19 Compact", "23 X 23 Compact", "27 X 27 Compact", "19 X 19", "23 X 23", "27 X 27", "31 X 31", "37 X 37", "41 X 41", "45 X 45", "49 X 49", "53 X 53", "57 X 57", "61 X 61", "67 X 67", "71 X 71", "75 X 75", "79 X 79", "83 X 83", "87 X 87", "91 X 91", "95 X 95", "101 X 101", "105 X 105", "109 X 109", "113 X 113", "117 X 117", "121 X 121", "125 X 125", "131 X 131", "135 X 135", "139 X 139", "143 X 143", "147 X 147", "151 X 151" }));
         aztecUserSizeCombo.setEnabled(false);
         aztecUserSizeCombo.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 aztecUserSizeComboActionPerformed(evt);
             }
@@ -650,6 +666,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
         aztecUserEccCombo.setModel(new javax.swing.DefaultComboBoxModel(new String[] { "10% + 3 words", "23% + 3 words", "36% + 3 words", "50% + 3 words" }));
         aztecUserEccCombo.setEnabled(false);
         aztecUserEccCombo.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 aztecUserEccComboActionPerformed(evt);
             }
@@ -692,6 +709,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
 
         channelChannelsCombo.setModel(new javax.swing.DefaultComboBoxModel(new String[] { "Automatic", "3", "4", "5", "6", "7", "8" }));
         channelChannelsCombo.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 channelChannelsComboActionPerformed(evt);
             }
@@ -721,6 +739,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
 
         code39CheckCombo.setModel(new javax.swing.DefaultComboBoxModel(new String[] { "No Check Digit", "Mod-43 Check Digit" }));
         code39CheckCombo.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 code39CheckComboActionPerformed(evt);
             }
@@ -750,6 +769,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
 
         codeOneSizeCombo.setModel(new javax.swing.DefaultComboBoxModel(new String[] { "Automatic", "16 X 18 (Version A)", "22 X 22 (Version B)", "28 X 32 (Version C)", "40 X 42 (Version D)", "52 X 54 (Version E)", "70 X 76 (Version F)", "104 X 98 (Version G)", "148 X 134 (Version H)", "8X Height (Version S)", "16X Height (Version T)" }));
         codeOneSizeCombo.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 codeOneSizeComboActionPerformed(evt);
             }
@@ -779,6 +799,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
 
         databarColumnsCombo.setModel(new javax.swing.DefaultComboBoxModel(new String[] { "Automatic", "1", "2", "3", "4", "5", "6", "7", "8", "9" }));
         databarColumnsCombo.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 databarColumnsComboActionPerformed(evt);
             }
@@ -808,6 +829,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
 
         dataMatrixSizeCombo.setModel(new javax.swing.DefaultComboBoxModel(new String[] { "Automatic", "10 X 10", "12 X 12", "14 X 14", "16 X 16", "18 X 18", "20 X 20", "22 X 22", "24 X 24", "26 X 26", "32 X 32", "36 X 36", "40 X 40", "44 X 44", "48 X 48", "52 X 52", "64 X 64", "72 X 72", "80 X 80", "88 X 88", "96 X 96", "104 X 104", "120 X 120", "132 X 132", "144 X 144", "8 X 18", "8 X 32", "12 X 26", "12 X 36", "16 X 36", "16 X 48" }));
         dataMatrixSizeCombo.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 dataMatrixSizeComboActionPerformed(evt);
             }
@@ -816,6 +838,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
         dataMatrixSquareOnlyCheck.setSelected(true);
         dataMatrixSquareOnlyCheck.setText("Supress Rectangular Symbols in Automatic Mode");
         dataMatrixSquareOnlyCheck.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 dataMatrixSquareOnlyCheckActionPerformed(evt);
             }
@@ -853,6 +876,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
         gridmatrixAutoSize.setSelected(true);
         gridmatrixAutoSize.setText("Automatic Resizing");
         gridmatrixAutoSize.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 gridmatrixAutoSizeActionPerformed(evt);
             }
@@ -861,6 +885,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
         gridmatrixButtonGroup.add(gridmatrixUserSize);
         gridmatrixUserSize.setText("Adjust Size To:");
         gridmatrixUserSize.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 gridmatrixUserSizeActionPerformed(evt);
             }
@@ -869,6 +894,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
         gridmatrixButtonGroup.add(gridmatrixUserEcc);
         gridmatrixUserEcc.setText("Add Minimum Error Correction:");
         gridmatrixUserEcc.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 gridmatrixUserEccActionPerformed(evt);
             }
@@ -877,6 +903,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
         gridmatrixUserSizeCombo.setModel(new javax.swing.DefaultComboBoxModel(new String[] { "18 X 18 (Version 1)", "30 X 30 (Version 2)", "42 X 42 (Version 3)", "54 X 54 (Version 4)", "66 X 66 (Version 5)", "78 X 78 (Version 6)", "90 X 90 (Version 7)", "102 X 102 (Version 8)", "114 X 114 (Version 9)", "126 X 126 (Version 10)", "138 X 138 (Version 11)", "150 X 150 (Version 12)", "162 X 162 (Version 13)" }));
         gridmatrixUserSizeCombo.setEnabled(false);
         gridmatrixUserSizeCombo.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 gridmatrixUserSizeComboActionPerformed(evt);
             }
@@ -885,6 +912,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
         gridmatrixUserEccCombo.setModel(new javax.swing.DefaultComboBoxModel(new String[] { "Approx 10%", "Approx 20%", "Approx 30%", "Approx 40%", "Approx 50%" }));
         gridmatrixUserEccCombo.setEnabled(false);
         gridmatrixUserEccCombo.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 gridmatrixUserEccComboActionPerformed(evt);
             }
@@ -931,6 +959,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
         maxiEncodingModeCombo.setSelectedIndex(2);
         maxiEncodingModeCombo.setToolTipText("");
         maxiEncodingModeCombo.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 maxiEncodingModeComboActionPerformed(evt);
             }
@@ -939,6 +968,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
         maxiPrimaryData.setText("Primary Data Here!");
         maxiPrimaryData.setEnabled(false);
         maxiPrimaryData.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 maxiPrimaryDataActionPerformed(evt);
             }
@@ -978,6 +1008,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
 
         microPdfColumnsCombo.setModel(new javax.swing.DefaultComboBoxModel(new String[] { "Automatic", "1", "2", "3", "4" }));
         microPdfColumnsCombo.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 microPdfColumnsComboActionPerformed(evt);
             }
@@ -1006,6 +1037,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
         microQrAutoSize.setSelected(true);
         microQrAutoSize.setText("Automatic Resizing");
         microQrAutoSize.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 microQrAutoSizeActionPerformed(evt);
             }
@@ -1014,6 +1046,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
         microQrButtonGroup.add(microQrUserSize);
         microQrUserSize.setText("Adjust Size To:");
         microQrUserSize.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 microQrUserSizeActionPerformed(evt);
             }
@@ -1022,6 +1055,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
         microQrButtonGroup.add(microQrUserEcc);
         microQrUserEcc.setText("Add Minimum Error Correction:");
         microQrUserEcc.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 microQrUserEccActionPerformed(evt);
             }
@@ -1030,6 +1064,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
         microQrUserSizeCombo.setModel(new javax.swing.DefaultComboBoxModel(new String[] { "11 X 11 (Version M1)", "13 X 13 (Version M2)", "15 X 15 (Version M3)", "17 X 17 (Version M4)" }));
         microQrUserSizeCombo.setEnabled(false);
         microQrUserSizeCombo.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 microQrUserSizeComboActionPerformed(evt);
             }
@@ -1038,6 +1073,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
         microQrUserEccCombo.setModel(new javax.swing.DefaultComboBoxModel(new String[] { "Approx 20% (Level L)", "Approx 37% (Level M)", "Approx 55% (Level Q)" }));
         microQrUserEccCombo.setEnabled(false);
         microQrUserEccCombo.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 microQrUserEccComboActionPerformed(evt);
             }
@@ -1079,6 +1115,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
 
         msiCheckDigitCombo.setModel(new javax.swing.DefaultComboBoxModel(new String[] { "None", "Mod-10", "Mod-10 & Mod-10", "Mod-11", "Mod-11 & Mod-10" }));
         msiCheckDigitCombo.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 msiCheckDigitComboActionPerformed(evt);
             }
@@ -1110,6 +1147,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
 
         pdfColumnsCombo.setModel(new javax.swing.DefaultComboBoxModel(new String[] { "Automatic", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20" }));
         pdfColumnsCombo.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 pdfColumnsComboActionPerformed(evt);
             }
@@ -1117,6 +1155,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
 
         pdfEccCombo.setModel(new javax.swing.DefaultComboBoxModel(new String[] { "Automatic", "2 words", "4 words", "8 words", "16 words", "32 words", "64 words", "128 words", "256 words", "512 words" }));
         pdfEccCombo.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 pdfEccComboActionPerformed(evt);
             }
@@ -1155,6 +1194,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
         qrAutoSize.setSelected(true);
         qrAutoSize.setText("Automatic Resizing");
         qrAutoSize.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 qrAutoSizeActionPerformed(evt);
             }
@@ -1163,6 +1203,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
         qrButtonGroup.add(qrUserSize);
         qrUserSize.setText("Adjust Size To:");
         qrUserSize.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 qrUserSizeActionPerformed(evt);
             }
@@ -1171,6 +1212,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
         qrButtonGroup.add(qrUserEcc);
         qrUserEcc.setText("Add Minimum Error Correction:");
         qrUserEcc.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 qrUserEccActionPerformed(evt);
             }
@@ -1179,6 +1221,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
         qrUserSizeCombo.setModel(new javax.swing.DefaultComboBoxModel(new String[] { "21 X 21 (Version 1)", "25 X 25 (Version 2)", "29 X 29 (Version 3)", "33 X 33 (Version 4)", "37 X 37 (Version 5)", "41 X 41 (Version 6)", "45 X 45 (Version 7)", "49 X 49 (Version 8)", "53 X 53 (Version 9)", "57 X 57 (Version 10)", "61 X 61 (Version 11)", "65 X 65 (Version 12)", "69 X 69 (Version 13)", "73 X 73 (Version 14)", "77 X 77 (Version 15)", "81 X 81 (Version 16)", "85 X 85 (Version 17)", "89 X 89 (Version 18)", "93 X 93 (Version 19)", "97 X 97 (Version 20)", "101 X 101 (Version 21)", "105 X 105 (Version 22)", "109 X 109 (Version 23)", "113 X 113 (Version 24)", "117 X 117 (Version 25)", "121 X 121 (Version 26)", "125 X 125 (Version 27)", "129 X 129 (Version 28)", "133 X 133 (Version 29)", "137 X 137 (Version 30)", "141 X 141 (Version 31)", "145 X 145 (Version 32)", "149 X 149 (Version 33)", "153 X 153 (Version 34)", "157 X 157 (Version 35)", "161 X 161 (Version 36)", "165 X 165 (Version 37)", "169 X 169 (Version 38)", "173 X 173 (Version 39)", "177 X 177 (Version 40)" }));
         qrUserSizeCombo.setEnabled(false);
         qrUserSizeCombo.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 qrUserSizeComboActionPerformed(evt);
             }
@@ -1187,6 +1230,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
         qrUserEccCombo.setModel(new javax.swing.DefaultComboBoxModel(new String[] { "Approx 20% (Level L)", "Approx 37% (Level M)", "Approx 55% (Level Q)", "Approx 65% (Level H)" }));
         qrUserEccCombo.setEnabled(false);
         qrUserEccCombo.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 qrUserEccComboActionPerformed(evt);
             }
@@ -1229,6 +1273,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
 
         compositeUserMode.setModel(new javax.swing.DefaultComboBoxModel(new String[] { "Automatic", "CC-A", "CC-B", "CC-C" }));
         compositeUserMode.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 compositeUserModeActionPerformed(evt);
             }
@@ -1309,6 +1354,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
 
         chkReaderInit.setText("Add reader initialisation");
         chkReaderInit.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 chkReaderInitActionPerformed(evt);
             }
@@ -1316,6 +1362,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
 
         cmbHrtPosition.setModel(new javax.swing.DefaultComboBoxModel(new String[] { "Below symbol", "Above symbol", "Don't display" }));
         cmbHrtPosition.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 cmbHrtPositionActionPerformed(evt);
             }
@@ -1333,6 +1380,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
 
         txtXDimension.setText("4");
         txtXDimension.addFocusListener(new java.awt.event.FocusAdapter() {
+            @Override
             public void focusLost(java.awt.event.FocusEvent evt) {
                 txtXDimensionFocusLost(evt);
             }
@@ -1340,6 +1388,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
 
         txtBorderWidth.setText("5");
         txtBorderWidth.addFocusListener(new java.awt.event.FocusAdapter() {
+            @Override
             public void focusLost(java.awt.event.FocusEvent evt) {
                 txtBorderWidthFocusLost(evt);
             }
@@ -1347,6 +1396,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
 
         txtWhitespaceWidth.setText("0");
         txtWhitespaceWidth.addFocusListener(new java.awt.event.FocusAdapter() {
+            @Override
             public void focusLost(java.awt.event.FocusEvent evt) {
                 txtWhitespaceWidthFocusLost(evt);
             }
@@ -1432,6 +1482,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
 
         exitButton.setText("Exit");
         exitButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 exitButtonActionPerformed(evt);
             }
@@ -1439,6 +1490,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
 
         saveButton.setText("Save");
         saveButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 saveButtonActionPerformed(evt);
             }
@@ -1446,6 +1498,7 @@ public class OkapiUI extends javax.swing.JFrame implements TreeSelectionListener
 
         aboutButton.setText("About");
         aboutButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 aboutButtonActionPerformed(evt);
             }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1161 - "@ Override" annotation should be used on any method overriding.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1161

Please let me know if you have any questions.

Faisal Hameed