### PR TITLE
Added missing hash

### DIFF
--- a/src/main/java/uk/org/okapibarcode/output/SvgRenderer.java
+++ b/src/main/java/uk/org/okapibarcode/output/SvgRenderer.java
@@ -117,7 +117,7 @@ public class SvgRenderer implements SymbolRenderer {
                       .append("\" text-anchor=\"middle\"\n");
                 writer.append("         font-family=\"").append(symbol.getFontName())
                       .append("\" font-size=\"").append(symbol.getFontSize() * magnification)
-                      .append("\" fill=\"").append(fgColour).append("\">\n");
+                      .append("\" fill=\"#").append(fgColour).append("\">\n");
                 writer.append("         ").append(text.text).append("\n");
                 writer.append("      </text>\n");
             }


### PR DESCRIPTION
Fixes the following error in log:

```
The attribute "fill" represents an invalid CSS value ("000000").
Original message:
The "fill" property does not support integer values.
```