### PR TITLE
Fill image background with paper color.

### DIFF
--- a/src/main/java/uk/org/okapibarcode/output/Java2DRenderer.java
+++ b/src/main/java/uk/org/okapibarcode/output/Java2DRenderer.java
@@ -68,6 +68,9 @@ public class Java2DRenderer implements SymbolRenderer {
     @Override
     public void render(Symbol symbol) {
 
+        g2d.setBackground(paper);
+        g2d.clearRect(0, 0, symbol.getWidth(), symbol.getHeight());
+
         int marginX = (int) (symbol.getQuietZoneHorizontal() * magnification);
         int marginY = (int) (symbol.getQuietZoneVertical() * magnification);
 


### PR DESCRIPTION
I try to save barcode in image file, but see only black rectangle (Windows 10 and Oracle Java 8).

So I add using paper color for background in render procedure.