### PR TITLE
in GS1 datamatrix, add capability to select the separator character between GS(29) and FNC1(232)

### DIFF
--- a/src/main/java/uk/org/okapibarcode/backend/DataMatrix.java
+++ b/src/main/java/uk/org/okapibarcode/backend/DataMatrix.java
@@ -124,6 +124,7 @@ public class DataMatrix extends Symbol {
     private int structuredAppendFileId = 1;
     private int structuredAppendPosition = 1;
     private int structuredAppendTotal = 1;
+    private boolean useGs;
 
     // internal state calculated when setContent() is called
 
@@ -136,6 +137,15 @@ public class DataMatrix extends Symbol {
     private int process_p;
     private int[] process_buffer = new int[8];
     private int codewordCount;
+
+    /**
+     * select the separator character to use, if true use GS(=>29) else use FNC1(=>232)
+     *
+     * @param useGs if true use GS(=>29) else use FNC1(=>232) as separator character
+     */
+    public void setUseGs(boolean useGs) {
+      this.useGs = useGs;
+    }
 
     /**
      * Forces the symbol to be either square or rectangular (non-square).
@@ -675,8 +685,14 @@ public class DataMatrix extends Symbol {
                             binary_length++;
                         } else {
                             if (inputData[sp] == FNC1) {
+                              if(useGs) {
+                                target[tp] = 29; /* GS */
+                                encodeInfo += "GS ";
+                              }
+                              else {
                                 target[tp] = 232; /* FNC1 */
                                 encodeInfo += "FNC1 ";
+                              }
                             } else {
                                 target[tp] = inputData[sp] + 1;
                                 encodeInfo += Integer.toString(target[tp] - 1) + " ";


### PR DESCRIPTION
https://www.gs1.org/docs/barcodes/GS1_DataMatrix_Guideline.pdf
The separator character may be FNC1 or the control character <GS> (ASCII value 29)
okapi barcode is currently using FNC1 as separator character.
i am facing a project where i have to use GS as separator character to be compliant with a regulation.
so i am adding the capability to switch between FNC1 and GS as separator character