### PR TITLE
Correct barcode height if no human readable

### DIFF
--- a/src/main/java/uk/org/okapibarcode/backend/Symbol.java
+++ b/src/main/java/uk/org/okapibarcode/backend/Symbol.java
@@ -336,7 +336,7 @@ public abstract class Symbol {
      * @return the height of the human-readable text
      */
     public int getHumanReadableHeight() {
-        if (texts.isEmpty()) {
+        if (texts.isEmpty() || humanReadableLocation == NONE) {
             return 0;
         } else {
             return getTheoreticalHumanReadableHeight();


### PR DESCRIPTION
Removes empty space at the bottom of the barcode