### PR TITLE
Update minimum 421 AI fixed size to 3

### DIFF
--- a/src/main/java/uk/org/okapibarcode/util/Gs1.java
+++ b/src/main/java/uk/org/okapibarcode/util/Gs1.java
@@ -502,7 +502,7 @@ public final class Gs1 {
             }
 
             if (ai_value[i] == 421) { // SHIP TO POST
-                if ((data_length[i] < 4) || (data_length[i] > 12)) {
+                if ((data_length[i] < 3) || (data_length[i] > 12)) {
                     error_latch = 1;
                 } else {
                     error_latch = 0;


### PR DESCRIPTION
The referenced rule given in below link shows ^421(\d{3})([\x21-\x22\x25-\x2F\x30-\x39\x3A-\x3F\x41-\x5A\x5F\x61-\x7A]{0,9})$ 
This indicates a minimum of 3 decimal.
https://www.gs1.org/standards/barcodes/application-identifiers/421?lang=en