### PR TITLE
Selecting the GS/FNC1 separator for DataMatrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,5 @@ jdk:
 script:
   - ./gradlew check
   - ./gradlew jacocoTestReport
-
+after_success:
+  - bash <(curl -s https://codecov.io/bash)  

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,4 @@ jdk:
 script:
   - ./gradlew check
   - ./gradlew jacocoTestReport
-after_success:
-  - bash <(curl -s https://codecov.io/bash)
+

--- a/src/main/java/uk/org/okapibarcode/backend/DataMatrix.java
+++ b/src/main/java/uk/org/okapibarcode/backend/DataMatrix.java
@@ -124,6 +124,7 @@ public class DataMatrix extends Symbol {
     private int structuredAppendFileId = 1;
     private int structuredAppendPosition = 1;
     private int structuredAppendTotal = 1;
+    private boolean useGS1;
 
     // internal state calculated when setContent() is called
 
@@ -136,6 +137,16 @@ public class DataMatrix extends Symbol {
     private int process_p;
     private int[] process_buffer = new int[8];
     private int codewordCount;
+    
+    /**
+     * In GS1 DataMatrix and GS1 DotCode symbology: The Function 1 Symbol Character (FNC1) or the
+     * control character <GS> SHALL be the separator character.
+     * 
+     * @param useGS1 if true use GS(=>29) else use FNC1(=>232) as separator character
+     */
+    public void setUseGS1(boolean useGS1) {
+      this.useGS1 = useGS1;
+    }
 
     /**
      * Forces the symbol to be either square or rectangular (non-square).
@@ -675,8 +686,14 @@ public class DataMatrix extends Symbol {
                             binary_length++;
                         } else {
                             if (inputData[sp] == FNC1) {
+                              if(useGS1) {
+                                target[tp] = 29 + 1; /* GS */
+                                encodeInfo += "GS ";
+                              }
+                              else {                                
                                 target[tp] = 232; /* FNC1 */
                                 info("FNC1 ");
+                              }
                             } else {
                                 target[tp] = inputData[sp] + 1;
                                 infoSpace(target[tp] - 1);
@@ -709,8 +726,13 @@ public class DataMatrix extends Symbol {
                     info("ASC ");
                 } else {
                     if (inputData[sp] == FNC1) {
+                      if(useGS1) {
+                        shift_set = 1;
+                        value = 29; /* GS */
+                      }else {
                         shift_set = 2;
                         value = 27; /* FNC1 */
+                      }  
                     } else if (inputData[sp] > 127) {
                         process_buffer[process_p] = 1;
                         process_p++;
@@ -777,8 +799,13 @@ public class DataMatrix extends Symbol {
                     info("ASC ");
                 } else {
                     if (inputData[sp] == FNC1) {
-                        shift_set = 2;
-                        value = 27; /* FNC1 */
+                      if(useGS1) {
+                        shift_set = 1;
+                        value = 29; /* GS */
+                      } else {  
+                          shift_set = 2;
+                          value = 27; /* FNC1 */
+                      }
                     } else if (inputData[sp] > 127) {
                         process_buffer[process_p] = 1;
                         process_p++;

--- a/src/main/java/uk/org/okapibarcode/backend/DataMatrix.java
+++ b/src/main/java/uk/org/okapibarcode/backend/DataMatrix.java
@@ -145,7 +145,7 @@ public class DataMatrix extends Symbol {
      * @param useGS1 if true use GS(=>29) else use FNC1(=>232) as separator character
      */
     public void setUseGS1(boolean useGS1) {
-      this.useGS1 = useGS1;
+      this.useGS1 = useGS1 ;
     }
 
     /**

--- a/src/main/java/uk/org/okapibarcode/backend/DataMatrix.java
+++ b/src/main/java/uk/org/okapibarcode/backend/DataMatrix.java
@@ -145,7 +145,7 @@ public class DataMatrix extends Symbol {
      * @param useGS1 if true use GS(=>29) else use FNC1(=>232) as separator character
      */
     public void setUseGS1(boolean useGS1) {
-      this.useGS1 = useGS1 ;
+      this.useGS1 = useGS1;
     }
 
     /**
@@ -688,7 +688,7 @@ public class DataMatrix extends Symbol {
                             if (inputData[sp] == FNC1) {
                               if(useGS1) {
                                 target[tp] = 29 + 1; /* GS */
-                                encodeInfo += "GS ";
+                                info ("GS ");
                               }
                               else {                                
                                 target[tp] = 232; /* FNC1 */

--- a/src/main/java/uk/org/okapibarcode/backend/DataMatrix.java
+++ b/src/main/java/uk/org/okapibarcode/backend/DataMatrix.java
@@ -124,7 +124,7 @@ public class DataMatrix extends Symbol {
     private int structuredAppendFileId = 1;
     private int structuredAppendPosition = 1;
     private int structuredAppendTotal = 1;
-    private boolean useGS1 = false;
+    private boolean useGS = false;
 
     // internal state calculated when setContent() is called
 
@@ -142,10 +142,10 @@ public class DataMatrix extends Symbol {
      * In GS1 DataMatrix and GS1 DotCode symbology: The Function 1 Symbol Character (FNC1) or the
      * control character <GS> SHALL be the separator character.
      * 
-     * @param useGS1 if true use GS(=>29) else use FNC1(=>232) as separator character
+     * @param useGS if true use GS(=>29) else use FNC1(=>232) as separator character
      */
-    public void setUseGS1(boolean useGS1) {
-      this.useGS1 = useGS1;
+    public void setUseGS(boolean useGS) {
+      this.useGS = useGS;
     }
 
     /**
@@ -686,14 +686,14 @@ public class DataMatrix extends Symbol {
                             binary_length++;
                         } else {
                             if (inputData[sp] == FNC1) {
-                              if(useGS1) {
-                                target[tp] = 29 + 1; /* GS */
-                                info ("GS ");
-                              }
-                              else {                                
-                                target[tp] = 232; /* FNC1 */
-                                info("FNC1 ");
-                              }
+                                if (useGS) {
+                                    target[tp] = 29 + 1; /* GS */
+                                    info ("GS ");
+                                }
+                                else {                                
+                                    target[tp] = 232; /* FNC1 */
+                                    info("FNC1 ");
+                                }
                             } else {
                                 target[tp] = inputData[sp] + 1;
                                 infoSpace(target[tp] - 1);
@@ -726,13 +726,13 @@ public class DataMatrix extends Symbol {
                     info("ASC ");
                 } else {
                     if (inputData[sp] == FNC1) {
-                      if(useGS1) {
-                        shift_set = 1;
-                        value = 29; /* GS */
-                      }else {
-                        shift_set = 2;
-                        value = 27; /* FNC1 */
-                      }  
+                        if (useGS) {
+                          shift_set = 1;
+                          value = 29; /* GS */
+                        } else {
+                            shift_set = 2;
+                            value = 27; /* FNC1 */
+                        }  
                     } else if (inputData[sp] > 127) {
                         process_buffer[process_p] = 1;
                         process_p++;
@@ -799,13 +799,13 @@ public class DataMatrix extends Symbol {
                     info("ASC ");
                 } else {
                     if (inputData[sp] == FNC1) {
-                      if(useGS1) {
-                        shift_set = 1;
-                        value = 29; /* GS */
-                      } else {  
-                          shift_set = 2;
-                          value = 27; /* FNC1 */
-                      }
+                        if (useGS) {
+                            shift_set = 1;
+                            value = 29; /* GS */
+                        } else {  
+                            shift_set = 2;
+                            value = 27; /* FNC1 */
+                        }
                     } else if (inputData[sp] > 127) {
                         process_buffer[process_p] = 1;
                         process_p++;

--- a/src/main/java/uk/org/okapibarcode/backend/DataMatrix.java
+++ b/src/main/java/uk/org/okapibarcode/backend/DataMatrix.java
@@ -124,7 +124,7 @@ public class DataMatrix extends Symbol {
     private int structuredAppendFileId = 1;
     private int structuredAppendPosition = 1;
     private int structuredAppendTotal = 1;
-    private boolean useGS1;
+    private boolean useGS1 = false;
 
     // internal state calculated when setContent() is called
 


### PR DESCRIPTION
In [GS1 General Specifications Release 21.0.1, Ratified, Jan 2021](https://www.gs1.org/docs/barcodes/GS1_General_Specifications.pdf)
p. 488 item "7.8.3 The separator character and its value" reads
"... In GS1 DataMatrix and GS1 DotCode symbology: The Function 1 Symbol Character (FNC1) or the
control character <GS> SHALL be the separator character. ..."

Some changes should be made to DataMatrix.java